### PR TITLE
Administrative fields for each logistic

### DIFF
--- a/lib/correios_sigep.rb
+++ b/lib/correios_sigep.rb
@@ -1,4 +1,5 @@
 require 'correios_sigep/version'
+require 'correios_sigep/models/administrative_fields'
 require 'correios_sigep/configuration'
 require 'correios_sigep/builders/xml/recipient'
 require 'correios_sigep/builders/xml/sender'

--- a/lib/correios_sigep/builders/xml/authentication.rb
+++ b/lib/correios_sigep/builders/xml/authentication.rb
@@ -2,18 +2,19 @@ module CorreiosSigep
   module Builders
     module XML
       class Authentication
-        def initialize(builder)
+        def initialize(builder, administrative_fields)
           @builder = builder
           @config = CorreiosSigep.configuration
+          @administrative_fields = administrative_fields
         end
 
         def build_xml!
           add_node "usuario", @config.user
           add_node "senha", @config.password
-          add_node "codAdministrativo", @config.administrative_code
-          add_node "contrato", @config.contract
-          add_node "codigo_servico", @config.service_code
-          add_node "cartao", @config.card
+          add_node "codAdministrativo", @administrative_fields.administrative_code
+          add_node "contrato", @administrative_fields.contract
+          add_node "codigo_servico", @administrative_fields.service_code
+          add_node "cartao", @administrative_fields.card
         end
 
         private

--- a/lib/correios_sigep/builders/xml/request.rb
+++ b/lib/correios_sigep/builders/xml/request.rb
@@ -3,9 +3,12 @@ module CorreiosSigep
     module XML
       class Request
 
-        def self.build_xml(request)
+        def self.build_xml(request, overrides={})
+          config = CorreiosSigep.configuration
           document = Nokogiri::XML(request.to_xml)
-          XML::Authentication.new(document).build_xml!
+          administrative_fields =
+            overrides[:administrative] || config.administrative_fields
+          XML::Authentication.new(document, administrative_fields).build_xml!
 
           document
             .to_xml(save_with: Nokogiri::XML::Node::SaveOptions::NO_DECLARATION)

--- a/lib/correios_sigep/configuration.rb
+++ b/lib/correios_sigep/configuration.rb
@@ -2,5 +2,13 @@ module CorreiosSigep
   class Configuration
     attr_accessor :administrative_code, :card, :contract, :password,
                   :service_code, :user, :wsdl_base_url, :proxy
+
+    def administrative_fields
+      @administrative_fields ||=
+        Models::AdministrativeFields.new(administrative_code: administrative_code,
+                                         card: card, contract: contract,
+                                         service_code: service_code)
+
+    end
   end
 end

--- a/lib/correios_sigep/models/administrative_fields.rb
+++ b/lib/correios_sigep/models/administrative_fields.rb
@@ -1,0 +1,14 @@
+module CorreiosSigep
+  module Models
+    class AdministrativeFields
+      attr_accessor :administrative_code, :card, :contract, :service_code
+
+      def initialize(options={})
+        self.administrative_code  = options[:administrative_code]
+        self.card                 = options[:card]
+        self.contract             = options[:contract]
+        self.service_code         = options[:service_code]
+      end
+    end
+  end
+end

--- a/lib/correios_sigep/version.rb
+++ b/lib/correios_sigep/version.rb
@@ -1,3 +1,3 @@
 module CorreiosSigep
-  VERSION = '0.1.1'
+  VERSION = '0.2.0'
 end

--- a/spec/correios_sigep/builders/xml/request_spec.rb
+++ b/spec/correios_sigep/builders/xml/request_spec.rb
@@ -1,0 +1,46 @@
+require 'spec_helper'
+require 'pry'
+
+module CorreiosSigep
+  module Builders
+    module XML
+      describe Request do
+        describe '.build_xml' do
+          let(:request) { double(:request, to_xml: '<root><test></root>') }
+          context 'when do not override anything' do
+            it 'builds a Authentication XML with Configuration parameters' do
+              expected_response = [
+                '<cartao>0057018901</cartao>',
+                '<codigo_servico>41076</codigo_servico>',
+                '<contrato>9912208555</contrato>',
+                '<codAdministrativo>08082650</codAdministrativo>',
+                '<senha>8o8otn</senha>',
+                '<usuario>60618043</usuario><test/>'
+              ].join + "\n"
+              expect(described_class.build_xml request).to eq expected_response
+            end
+          end
+
+          context 'when override the administrative fields' do
+            it 'builds a Authentication XML with the override parameter' do
+              administrative_fields = Models::AdministrativeFields.new(administrative_code: 'adm123',
+                                                                       card: 'card123',
+                                                                       contract: 'cont123',
+                                                                       service_code: 'ser123')
+              expected_response = [
+                '<cartao>card123</cartao>',
+                '<codigo_servico>ser123</codigo_servico>',
+                '<contrato>cont123</contrato>',
+                '<codAdministrativo>adm123</codAdministrativo>',
+                '<senha>8o8otn</senha>',
+                '<usuario>60618043</usuario><test/>'
+              ].join + "\n"
+              expect(described_class.build_xml request, administrative: administrative_fields).to eq expected_response
+            end
+          end
+
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
With this feature, it's possible to create a logistic reverse for different administrative_code/contract/card for each logistic reverse. This behave it's from 1 client using correios_sigep. 