### PR TITLE
Add net_http_persistent as default Savon adapter

### DIFF
--- a/correios_sigep.gemspec
+++ b/correios_sigep.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
+  spec.add_dependency 'net-http-persistent', '~> 2.9.4'
   spec.add_dependency 'savon', '~> 2.0'
 
   spec.add_development_dependency 'bundler', '~> 1.7'

--- a/lib/correios_sigep.rb
+++ b/lib/correios_sigep.rb
@@ -33,6 +33,7 @@ require 'correios_sigep/models/errors/collect_number_not_found'
 require 'correios_sigep/logistic_reverse/base_client'
 require 'correios_sigep/logistic_reverse/request_collect_number'
 require 'correios_sigep/logistic_reverse/request_sro'
+require 'net/http/persistent'
 require 'nokogiri'
 require 'savon'
 

--- a/lib/correios_sigep/logistic_reverse/base_client.rb
+++ b/lib/correios_sigep/logistic_reverse/base_client.rb
@@ -2,7 +2,7 @@ module CorreiosSigep
   module LogisticReverse
     class BaseClient
       def initialize
-        options = { wsdl: wsdl, proxy: CorreiosSigep.configuration.proxy }
+        options = { adapter: :net_http_persistent, proxy: CorreiosSigep.configuration.proxy, wsdl: wsdl }
         options.delete(:proxy) unless options[:proxy]
 
         @client = Savon.client(options)

--- a/spec/correios_sigep/logistic_reverse/base_client_spec.rb
+++ b/spec/correios_sigep/logistic_reverse/base_client_spec.rb
@@ -10,8 +10,9 @@ module CorreiosSigep
           before { CorreiosSigep.configuration.proxy = 'http://localhost' }
           let(:params) do
             {
-              wsdl:  described_class.new.wsdl,
-              proxy: CorreiosSigep.configuration.proxy
+              adapter: :net_http_persistent,
+              proxy: CorreiosSigep.configuration.proxy,
+              wsdl:  described_class.new.wsdl
             }
           end
 
@@ -23,7 +24,7 @@ module CorreiosSigep
 
         context 'without a proxy' do
           before { CorreiosSigep.configuration.proxy = nil }
-          let(:params) { { wsdl: described_class.new.wsdl } }
+          let(:params) { { adapter: :net_http_persistent, wsdl: described_class.new.wsdl } }
 
           it 'initializes @client without proxy' do
             expect(Savon).to receive(:client).with(params) { true }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 ENV['GEM_ENV'] = 'test'
+require 'pry'
 require 'simplecov'
 require 'support/logistic_reverse_helper'
 require 'support/fixture_helper'


### PR DESCRIPTION
Using the default Savon adapter in correios_sigep in a multi-thread environment is causing problems with  an `undefined method '+'` that is raising on net_http.

This PR will use the net_http_persistent that is a thread-safe http lib. 

:beers: 

After merge, please update the version :smile: 