### PR TITLE
Handle Correios response for SRO when object is an array

### DIFF
--- a/lib/correios_sigep/logistic_reverse/request_sro.rb
+++ b/lib/correios_sigep/logistic_reverse/request_sro.rb
@@ -15,14 +15,19 @@ module CorreiosSigep
       private
       def process_response response
         correios_hash = response.body[:acompanhar_pedido_response][:return]
-        check_sro_errors correios_hash
-        correios_hash[:coleta][:objeto][:numero_etiqueta] || begin raise Models::Errors::SRONotReady; end
+        check_sro_errors(correios_hash)
+        correios_response(correios_hash[:coleta][:objeto])[:numero_etiqueta] || begin raise Models::Errors::SRONotReady; end
+      end
+
+      def correios_response response
+        response.is_a?(Array) ? response.first : response
       end
 
       def check_sro_errors return_body
         error_msg = return_body[:msg_erro]
         case return_body[:cod_erro].to_i
         when 0
+          return
         when -7
           raise Models::Errors::RequiredFields.new(error_msg)
         when -5

--- a/spec/correios_sigep/logistic_reverse/request_sro_spec.rb
+++ b/spec/correios_sigep/logistic_reverse/request_sro_spec.rb
@@ -65,6 +65,14 @@ module CorreiosSigep
           end
         end
 
+        context 'when response is an array' do
+          let(:response_body) { 'response_array_success.xml' }
+
+          it 'returns sro ticket' do
+            expect(subject).to eq 'ETI12345'
+          end
+        end
+
       end
     end
   end

--- a/spec/fixtures/correios/request_sro/response_array_success.xml
+++ b/spec/fixtures/correios/request_sro/response_array_success.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<S:Envelope xmlns:S="http://schemas.xmlsoap.org/soap/envelope/">
+  <S:Body>
+    <ns2:acompanharPedidoResponse xmlns:ns2="http://webservice.scol.correios.com.br/">
+      <return>
+        <codigo_administrativo>0808265</codigo_administrativo>
+        <tipo_solicitacao>A</tipo_solicitacao>
+        <coleta>
+           <numero_pedido>1234</numero_pedido>
+           <controle_cliente>56789</controle_cliente>
+           <historico>
+              <status>55</status>
+              <descricao_status>Aguardando Objeto na Agência</descricao_status>
+              <data_atualizacao>16-07-2015</data_atualizacao>
+              <hora_atualizacao>11:02:36</hora_atualizacao>
+              <observacao/>
+           </historico>
+           <objeto>
+              <numero_etiqueta>ETI12345</numero_etiqueta>
+              <controle_objeto_cliente>2696523</controle_objeto_cliente>
+              <ultimo_status>55</ultimo_status>
+              <descricao_status>Aguardando Objeto na Agência</descricao_status>
+              <data_ultima_atualizacao>16-07-2015</data_ultima_atualizacao>
+              <hora_ultima_atualizacao>11:02:36</hora_ultima_atualizacao>
+           </objeto>
+           <objeto>
+              <numero_etiqueta></numero_etiqueta>
+              <controle_objeto_cliente>2696523</controle_objeto_cliente>
+              <ultimo_status>55</ultimo_status>
+              <descricao_status>Aguardando Objeto na Agência</descricao_status>
+              <data_ultima_atualizacao>16-07-2015</data_ultima_atualizacao>
+              <hora_ultima_atualizacao>11:02:36</hora_ultima_atualizacao>
+           </objeto>
+        </coleta>
+      </return>
+    </ns2:acompanharPedidoResponse>
+  </S:Body>
+</S:Envelope>


### PR DESCRIPTION
For some **random** reason :confused: Correios response can be an `Array` (for more objects, which is weird because it's a _REVERSE_) or a `Hash`. I believe that it can be for 'posting' (postagem) and 'collect' (coleta). But what we need is always the first one. I'd like to see this PR's behavior in production and hope for the best :pray: 

Cheers :beer: 