### PR TITLE
Fix object to work in sandbox env

### DIFF
--- a/lib/correios_sigep/builders/xml/collect_objects.rb
+++ b/lib/correios_sigep/builders/xml/collect_objects.rb
@@ -20,7 +20,7 @@ module CorreiosSigep
           @builder.item  object.item
           @builder.id    object.id
           @builder.desc  object.description
-          @builder.ship  object.ship
+          @builder.entrega  object.ship
           @builder.num   object.num
         end
       end

--- a/lib/correios_sigep/logistic_reverse/base_client.rb
+++ b/lib/correios_sigep/logistic_reverse/base_client.rb
@@ -5,6 +5,8 @@ module CorreiosSigep
         options = { adapter: :net_http_persistent, proxy: CorreiosSigep.configuration.proxy, wsdl: wsdl }
         options.delete(:proxy) unless options[:proxy]
 
+        options.merge!({ headers: { 'SOAPAction' => '' }}) if ENV['GEM_ENV'] == 'test'
+
         @client = Savon.client(options)
       end
 

--- a/spec/correios_sigep/logistic_reverse/base_client_spec.rb
+++ b/spec/correios_sigep/logistic_reverse/base_client_spec.rb
@@ -12,7 +12,8 @@ module CorreiosSigep
             {
               adapter: :net_http_persistent,
               proxy: CorreiosSigep.configuration.proxy,
-              wsdl:  described_class.new.wsdl
+              wsdl:  described_class.new.wsdl,
+              headers: { 'SOAPAction' => '' }
             }
           end
 
@@ -24,7 +25,13 @@ module CorreiosSigep
 
         context 'without a proxy' do
           before { CorreiosSigep.configuration.proxy = nil }
-          let(:params) { { adapter: :net_http_persistent, wsdl: described_class.new.wsdl } }
+          let(:params) do
+            {
+              adapter: :net_http_persistent,
+              wsdl: described_class.new.wsdl,
+              headers: { 'SOAPAction' => '' }
+            }
+          end
 
           it 'initializes @client without proxy' do
             expect(Savon).to receive(:client).with(params) { true }

--- a/spec/correios_sigep/logistic_reverse/request_collect_number_spec.rb
+++ b/spec/correios_sigep/logistic_reverse/request_collect_number_spec.rb
@@ -13,14 +13,14 @@ module CorreiosSigep
         # WSDL
         stub_request(:get, "http://webservicescolhomologacao.correios.com.br/ScolWeb/WebServiceScol?wsdl").
           with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'User-Agent'=>'Ruby'}).
-          to_return(:status => 200, :body => correios_fixture('wsdl.xml'), :headers => {})
+          to_return(:status => 200, :body => correios_fixture('wsdl_test.xml'), :headers => {})
 
         # REQUEST
         stub_request(:post, "http://webservicescolhomologacao.correios.com.br/ScolWeb/WebServiceScol").
          with(:body => body, :headers => { 'Accept'=>'*/*',
             'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
             'Content-Length'=>'2267', 'Content-Type'=>'text/xml;charset=UTF-8',
-            'Soapaction'=>'"solicitarPostagemReversa"', 'User-Agent'=>'Ruby' }).
+            'Soapaction'=>'', 'User-Agent'=>'Ruby' }).
          to_return(:status => 200, :body => correios_fixture("request_collect_number/#{response_body}"), :headers => {})
       end
 

--- a/spec/correios_sigep/logistic_reverse/request_collect_number_spec.rb
+++ b/spec/correios_sigep/logistic_reverse/request_collect_number_spec.rb
@@ -19,7 +19,7 @@ module CorreiosSigep
         stub_request(:post, "http://webservicescolhomologacao.correios.com.br/ScolWeb/WebServiceScol").
          with(:body => body, :headers => { 'Accept'=>'*/*',
             'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-            'Content-Length'=>'2267', 'Content-Type'=>'text/xml;charset=UTF-8',
+            'Content-Length'=>'2279', 'Content-Type'=>'text/xml;charset=UTF-8',
             'Soapaction'=>'', 'User-Agent'=>'Ruby' }).
          to_return(:status => 200, :body => correios_fixture("request_collect_number/#{response_body}"), :headers => {})
       end

--- a/spec/correios_sigep/logistic_reverse/request_sro_spec.rb
+++ b/spec/correios_sigep/logistic_reverse/request_sro_spec.rb
@@ -18,7 +18,7 @@ module CorreiosSigep
          with(:body => body, :headers => { 'Accept'=>'*/*',
             'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
             'Content-Length'=>'633', 'Content-Type'=>'text/xml;charset=UTF-8',
-            'Soapaction'=>'"acompanharPedido"', 'User-Agent'=>'Ruby' }).
+            'Soapaction'=>'', 'User-Agent'=>'Ruby' }).
          to_return(:status => 200, :body => correios_fixture("request_sro/#{response_body}"), :headers => {})
       end
 

--- a/spec/fixtures/builders/logistic_reverse.xml
+++ b/spec/fixtures/builders/logistic_reverse.xml
@@ -52,14 +52,14 @@
       <item>127078</item>
       <id>1405670</id>
       <desc>Pen Drive SAndisk 16GB SDCZ50-016G-A95</desc>
-      <ship>ship</ship>
+      <entrega>ship</entrega>
       <num>1</num>
     </obj_col>
     <obj_col>
       <item>277574</item>
       <id>1405670</id>
       <desc>Chip unico claro Pre pago</desc>
-      <ship>ship</ship>
+      <entrega>ship</entrega>
       <num>2</num>
     </obj_col>
   </coletas_solicitadas>

--- a/spec/fixtures/builders/request_collect_number.xml
+++ b/spec/fixtures/builders/request_collect_number.xml
@@ -51,14 +51,14 @@
       <item>127078</item>
       <id>1405670</id>
       <desc>Pen Drive SAndisk 16GB SDCZ50-016G-A95</desc>
-      <ship>ship</ship>
+      <entrega>ship</entrega>
       <num>1</num>
     </obj_col>
     <obj_col>
       <item>277574</item>
       <id>1405670</id>
       <desc>Chip unico claro Pre pago</desc>
-      <ship>ship</ship>
+      <entrega>ship</entrega>
       <num>2</num>
     </obj_col>
   </coletas_solicitadas>

--- a/spec/fixtures/correios/wsdl_test.xml
+++ b/spec/fixtures/correios/wsdl_test.xml
@@ -1,0 +1,616 @@
+<?xml version='1.0' encoding='UTF-8'?><wsdl:definitions xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:tns="http://webservice.scol.correios.com.br/" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:ns1="http://schemas.xmlsoap.org/soap/http" name="WebServiceScol" targetNamespace="http://webservice.scol.correios.com.br/">
+  <wsdl:types>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://webservice.scol.correios.com.br/" elementFormDefault="unqualified" targetNamespace="http://webservice.scol.correios.com.br/" version="1.0">
+
+  <xs:element name="acompanharPedido" type="tns:acompanharPedido"/>
+
+  <xs:element name="acompanharPedidoResponse" type="tns:acompanharPedidoResponse"/>
+
+  <xs:element name="calcularDigitoVerificador" type="tns:calcularDigitoVerificador"/>
+
+  <xs:element name="calcularDigitoVerificadorResponse" type="tns:calcularDigitoVerificadorResponse"/>
+
+  <xs:element name="cancelarPedido" type="tns:cancelarPedido"/>
+
+  <xs:element name="cancelarPedidoResponse" type="tns:cancelarPedidoResponse"/>
+
+  <xs:element name="solicitarPostagem" type="tns:solicitarPostagem"/>
+
+  <xs:element name="solicitarPostagemResponse" type="tns:solicitarPostagemResponse"/>
+
+  <xs:element name="solicitarPostagemReversa" type="tns:solicitarPostagemReversa"/>
+
+  <xs:element name="solicitarPostagemReversaResponse" type="tns:solicitarPostagemReversaResponse"/>
+
+  <xs:element name="solicitarPostagemSimultanea" type="tns:solicitarPostagemSimultanea"/>
+
+  <xs:element name="solicitarPostagemSimultaneaResponse" type="tns:solicitarPostagemSimultaneaResponse"/>
+
+  <xs:element name="solicitarRange" type="tns:solicitarRange"/>
+
+  <xs:element name="solicitarRangeResponse" type="tns:solicitarRangeResponse"/>
+
+  <xs:element name="validarPostagemReversa" type="tns:validarPostagemReversa"/>
+
+  <xs:element name="validarPostagemReversaResponse" type="tns:validarPostagemReversaResponse"/>
+
+  <xs:element name="validarPostagemSimultanea" type="tns:validarPostagemSimultanea"/>
+
+  <xs:element name="validarPostagemSimultaneaResponse" type="tns:validarPostagemSimultaneaResponse"/>
+
+  <xs:complexType name="validarPostagemSimultanea">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="usuario" type="xs:string"/>
+      <xs:element minOccurs="0" name="senha" type="xs:string"/>
+      <xs:element minOccurs="0" name="codAdministrativo" type="xs:int"/>
+      <xs:element minOccurs="0" name="codigo_servico" type="xs:int"/>
+      <xs:element minOccurs="0" name="cep_destinatario" type="xs:string"/>
+      <xs:element minOccurs="0" name="coleta" type="tns:coletaSimultaneaTO"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="coletaSimultaneaTO">
+    <xs:complexContent>
+      <xs:extension base="tns:coletaTO">
+        <xs:sequence>
+          <xs:element minOccurs="0" name="obs" type="xs:string"/>
+          <xs:element minOccurs="0" name="obj" type="xs:string"/>
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:complexType name="coletaTO">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="tipo" type="xs:string"/>
+      <xs:element minOccurs="0" name="id_cliente" type="xs:string"/>
+      <xs:element minOccurs="0" name="valor_declarado" type="xs:string"/>
+      <xs:element minOccurs="0" name="descricao" type="xs:string"/>
+      <xs:element minOccurs="0" name="cklist" type="xs:string"/>
+      <xs:element minOccurs="0" name="remetente" type="tns:remetenteTO"/>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="produto" nillable="true" type="tns:produtoTO"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="remetenteTO">
+    <xs:complexContent>
+      <xs:extension base="tns:pessoaTO">
+        <xs:sequence>
+          <xs:element minOccurs="0" name="identificacao" type="xs:string"/>
+          <xs:element minOccurs="0" name="ddd_celular" type="xs:string"/>
+          <xs:element minOccurs="0" name="celular" type="xs:string"/>
+          <xs:element minOccurs="0" name="sms" type="xs:string"/>
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:complexType name="pessoaTO">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="nome" type="xs:string"/>
+      <xs:element minOccurs="0" name="logradouro" type="xs:string"/>
+      <xs:element minOccurs="0" name="numero" type="xs:string"/>
+      <xs:element minOccurs="0" name="complemento" type="xs:string"/>
+      <xs:element minOccurs="0" name="bairro" type="xs:string"/>
+      <xs:element minOccurs="0" name="referencia" type="xs:string"/>
+      <xs:element minOccurs="0" name="cidade" type="xs:string"/>
+      <xs:element minOccurs="0" name="uf" type="xs:string"/>
+      <xs:element minOccurs="0" name="cep" type="xs:string"/>
+      <xs:element minOccurs="0" name="ddd" type="xs:string"/>
+      <xs:element minOccurs="0" name="telefone" type="xs:string"/>
+      <xs:element minOccurs="0" name="email" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="produtoTO">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="codigo" type="xs:string"/>
+      <xs:element minOccurs="0" name="tipo" type="xs:string"/>
+      <xs:element minOccurs="0" name="qtd" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="validarPostagemSimultaneaResponse">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="return" type="tns:retornoValidacaoTO"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="retornoValidacaoTO">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="cod_erro" type="xs:long"/>
+      <xs:element minOccurs="0" name="msg_erro" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="solicitarPostagem">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="usuario" type="xs:string"/>
+      <xs:element minOccurs="0" name="senha" type="xs:string"/>
+      <xs:element minOccurs="0" name="codAdministrativo" type="xs:int"/>
+      <xs:element minOccurs="0" name="xml" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="solicitarPostagemResponse">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="return" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="calcularDigitoVerificador">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="usuario" type="xs:string"/>
+      <xs:element minOccurs="0" name="senha" type="xs:string"/>
+      <xs:element minOccurs="0" name="codAdministrativo" type="xs:int"/>
+      <xs:element minOccurs="0" name="numero" type="xs:int"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="calcularDigitoVerificadorResponse">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="return" type="tns:retornoDigitoVerificadorTO"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="retornoDigitoVerificadorTO">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="data" type="xs:string"/>
+      <xs:element minOccurs="0" name="hora" type="xs:string"/>
+      <xs:element minOccurs="0" name="cod_erro" type="xs:string"/>
+      <xs:element minOccurs="0" name="msg_erro" type="xs:string"/>
+      <xs:element minOccurs="0" name="digito" type="xs:int"/>
+      <xs:element minOccurs="0" name="numero" type="xs:int"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="solicitarPostagemReversa">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="usuario" type="xs:string"/>
+      <xs:element minOccurs="0" name="senha" type="xs:string"/>
+      <xs:element minOccurs="0" name="codAdministrativo" type="xs:int"/>
+      <xs:element minOccurs="0" name="contrato" type="xs:string"/>
+      <xs:element minOccurs="0" name="codigo_servico" type="xs:int"/>
+      <xs:element minOccurs="0" name="cartao" type="xs:string"/>
+      <xs:element minOccurs="0" name="destinatario" type="tns:pessoaTO"/>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="coletas_solicitadas" type="tns:coletaReversaTO"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="coletaReversaTO">
+    <xs:complexContent>
+      <xs:extension base="tns:coletaTO">
+        <xs:sequence>
+          <xs:element minOccurs="0" name="numero" type="xs:int"/>
+          <xs:element minOccurs="0" name="ag" type="xs:string"/>
+          <xs:element minOccurs="0" name="cartao" type="xs:string"/>
+          <xs:element minOccurs="0" name="servico_adicional" type="xs:string"/>
+          <xs:element minOccurs="0" name="ar" type="xs:int"/>
+          <xs:element maxOccurs="unbounded" minOccurs="0" name="obj_col" nillable="true" type="tns:objetoTO"/>
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:complexType name="objetoTO">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="item" type="xs:string"/>
+      <xs:element minOccurs="0" name="desc" type="xs:string"/>
+      <xs:element minOccurs="0" name="entrega" type="xs:string"/>
+      <xs:element minOccurs="0" name="num" type="xs:string"/>
+      <xs:element minOccurs="0" name="id" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="solicitarPostagemReversaResponse">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="return" type="tns:retornoPostagemTO"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="retornoPostagemTO">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="status_processamento" type="xs:string"/>
+      <xs:element minOccurs="0" name="data_processamento" type="xs:string"/>
+      <xs:element minOccurs="0" name="hora_processamento" type="xs:string"/>
+      <xs:element minOccurs="0" name="cod_erro" type="xs:string"/>
+      <xs:element minOccurs="0" name="msg_erro" type="xs:string"/>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="resultado_solicitacao" nillable="true" type="tns:resultadoSolicitacaoTO"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="resultadoSolicitacaoTO">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="tipo" type="xs:string"/>
+      <xs:element minOccurs="0" name="id_cliente" type="xs:string"/>
+      <xs:element minOccurs="0" name="numero_coleta" type="xs:string"/>
+      <xs:element minOccurs="0" name="numero_etiqueta" type="xs:string"/>
+      <xs:element minOccurs="0" name="id_obj" type="xs:string"/>
+      <xs:element minOccurs="0" name="status_objeto" type="xs:string"/>
+      <xs:element minOccurs="0" name="prazo" type="xs:string"/>
+      <xs:element minOccurs="0" name="data_solicitacao" type="xs:string"/>
+      <xs:element minOccurs="0" name="hora_solicitacao" type="xs:string"/>
+      <xs:element name="codigo_erro" type="xs:long"/>
+      <xs:element minOccurs="0" name="descricao_erro" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="solicitarRange">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="usuario" type="xs:string"/>
+      <xs:element minOccurs="0" name="senha" type="xs:string"/>
+      <xs:element minOccurs="0" name="codAdministrativo" type="xs:int"/>
+      <xs:element minOccurs="0" name="contrato" type="xs:string"/>
+      <xs:element minOccurs="0" name="tipo" type="xs:string"/>
+      <xs:element minOccurs="0" name="servico" type="xs:string"/>
+      <xs:element minOccurs="0" name="quantidade" type="xs:int"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="solicitarRangeResponse">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="return" type="tns:retornoFaixaNumericaTO"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="retornoFaixaNumericaTO">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="data" type="xs:string"/>
+      <xs:element minOccurs="0" name="hora" type="xs:string"/>
+      <xs:element minOccurs="0" name="cod_erro" type="xs:string"/>
+      <xs:element minOccurs="0" name="msg_erro" type="xs:string"/>
+      <xs:element minOccurs="0" name="faixa_inicial" type="xs:int"/>
+      <xs:element minOccurs="0" name="faixa_final" type="xs:int"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="solicitarPostagemSimultanea">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="usuario" type="xs:string"/>
+      <xs:element minOccurs="0" name="senha" type="xs:string"/>
+      <xs:element minOccurs="0" name="codAdministrativo" type="xs:int"/>
+      <xs:element minOccurs="0" name="contrato" type="xs:string"/>
+      <xs:element minOccurs="0" name="codigo_servico" type="xs:int"/>
+      <xs:element minOccurs="0" name="cartao" type="xs:string"/>
+      <xs:element minOccurs="0" name="destinatario" type="tns:pessoaTO"/>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="coletas_solicitadas" type="tns:coletaSimultaneaTO"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="solicitarPostagemSimultaneaResponse">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="return" type="tns:retornoPostagemTO"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="acompanharPedido">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="usuario" type="xs:string"/>
+      <xs:element minOccurs="0" name="senha" type="xs:string"/>
+      <xs:element minOccurs="0" name="codAdministrativo" type="xs:int"/>
+      <xs:element minOccurs="0" name="tipoBusca" type="xs:string"/>
+      <xs:element minOccurs="0" name="tipoSolicitacao" type="xs:string"/>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="numeroPedido" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="acompanharPedidoResponse">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="return" type="tns:retornoAcompanhamentoTO"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="retornoAcompanhamentoTO">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="codigo_administrativo" type="xs:string"/>
+      <xs:element minOccurs="0" name="tipo_solicitacao" type="xs:string"/>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="coleta" nillable="true" type="tns:coletasSolicitadasTO"/>
+      <xs:element minOccurs="0" name="data" type="xs:string"/>
+      <xs:element minOccurs="0" name="hora" type="xs:string"/>
+      <xs:element minOccurs="0" name="cod_erro" type="xs:string"/>
+      <xs:element minOccurs="0" name="msg_erro" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="coletasSolicitadasTO">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="numero_pedido" type="xs:int"/>
+      <xs:element minOccurs="0" name="controle_cliente" type="xs:string"/>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="historico" nillable="true" type="tns:historicoColetaTO"/>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="objeto" nillable="true" type="tns:objetoPostalTO"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="historicoColetaTO">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="status" type="xs:int"/>
+      <xs:element minOccurs="0" name="descricao_status" type="xs:string"/>
+      <xs:element minOccurs="0" name="data_atualizacao" type="xs:string"/>
+      <xs:element minOccurs="0" name="hora_atualizacao" type="xs:string"/>
+      <xs:element minOccurs="0" name="observacao" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="objetoPostalTO">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="numero_etiqueta" type="xs:string"/>
+      <xs:element minOccurs="0" name="controle_objeto_cliente" type="xs:string"/>
+      <xs:element minOccurs="0" name="ultimo_status" type="xs:string"/>
+      <xs:element minOccurs="0" name="descricao_status" type="xs:string"/>
+      <xs:element minOccurs="0" name="data_ultima_atualizacao" type="xs:string"/>
+      <xs:element minOccurs="0" name="hora_ultima_atualizacao" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="validarPostagemReversa">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="usuario" type="xs:string"/>
+      <xs:element minOccurs="0" name="senha" type="xs:string"/>
+      <xs:element minOccurs="0" name="codAdministrativo" type="xs:int"/>
+      <xs:element minOccurs="0" name="codigo_servico" type="xs:int"/>
+      <xs:element minOccurs="0" name="cep_destinatario" type="xs:string"/>
+      <xs:element minOccurs="0" name="coleta" type="tns:coletaReversaTO"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="validarPostagemReversaResponse">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="return" type="tns:retornoValidacaoTO"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="cancelarPedido">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="usuario" type="xs:string"/>
+      <xs:element minOccurs="0" name="senha" type="xs:string"/>
+      <xs:element minOccurs="0" name="codAdministrativo" type="xs:int"/>
+      <xs:element minOccurs="0" name="numeroPedido" type="xs:string"/>
+      <xs:element minOccurs="0" name="tipo" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="cancelarPedidoResponse">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="return" type="tns:retornoCancelamentoTO"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="retornoCancelamentoTO">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="codigo_administrativo" type="xs:string"/>
+      <xs:element minOccurs="0" name="objeto_postal" type="tns:objetoSimplificadoTO"/>
+      <xs:element minOccurs="0" name="data" type="xs:string"/>
+      <xs:element minOccurs="0" name="hora" type="xs:string"/>
+      <xs:element minOccurs="0" name="cod_erro" type="xs:string"/>
+      <xs:element minOccurs="0" name="msg_erro" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="objetoSimplificadoTO">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="numero_pedido" type="xs:int"/>
+      <xs:element minOccurs="0" name="status_pedido" type="xs:string"/>
+      <xs:element minOccurs="0" name="datahora_cancelamento" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+
+</xs:schema>
+  </wsdl:types>
+  <wsdl:message name="solicitarRangeResponse">
+    <wsdl:part element="tns:solicitarRangeResponse" name="parameters">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="solicitarPostagemResponse">
+    <wsdl:part element="tns:solicitarPostagemResponse" name="parameters">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="acompanharPedidoResponse">
+    <wsdl:part element="tns:acompanharPedidoResponse" name="parameters">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="solicitarPostagemReversa">
+    <wsdl:part element="tns:solicitarPostagemReversa" name="parameters">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="solicitarPostagemSimultanea">
+    <wsdl:part element="tns:solicitarPostagemSimultanea" name="parameters">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="calcularDigitoVerificador">
+    <wsdl:part element="tns:calcularDigitoVerificador" name="parameters">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="solicitarRange">
+    <wsdl:part element="tns:solicitarRange" name="parameters">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="validarPostagemReversaResponse">
+    <wsdl:part element="tns:validarPostagemReversaResponse" name="parameters">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="cancelarPedido">
+    <wsdl:part element="tns:cancelarPedido" name="parameters">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="solicitarPostagemSimultaneaResponse">
+    <wsdl:part element="tns:solicitarPostagemSimultaneaResponse" name="parameters">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="acompanharPedido">
+    <wsdl:part element="tns:acompanharPedido" name="parameters">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="validarPostagemSimultaneaResponse">
+    <wsdl:part element="tns:validarPostagemSimultaneaResponse" name="parameters">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="solicitarPostagem">
+    <wsdl:part element="tns:solicitarPostagem" name="parameters">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="validarPostagemSimultanea">
+    <wsdl:part element="tns:validarPostagemSimultanea" name="parameters">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="validarPostagemReversa">
+    <wsdl:part element="tns:validarPostagemReversa" name="parameters">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="calcularDigitoVerificadorResponse">
+    <wsdl:part element="tns:calcularDigitoVerificadorResponse" name="parameters">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="cancelarPedidoResponse">
+    <wsdl:part element="tns:cancelarPedidoResponse" name="parameters">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="solicitarPostagemReversaResponse">
+    <wsdl:part element="tns:solicitarPostagemReversaResponse" name="parameters">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:portType name="WebServiceScol">
+    <wsdl:operation name="validarPostagemSimultanea">
+      <wsdl:input message="tns:validarPostagemSimultanea" name="validarPostagemSimultanea">
+    </wsdl:input>
+      <wsdl:output message="tns:validarPostagemSimultaneaResponse" name="validarPostagemSimultaneaResponse">
+    </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="solicitarPostagem">
+      <wsdl:input message="tns:solicitarPostagem" name="solicitarPostagem">
+    </wsdl:input>
+      <wsdl:output message="tns:solicitarPostagemResponse" name="solicitarPostagemResponse">
+    </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="calcularDigitoVerificador">
+      <wsdl:input message="tns:calcularDigitoVerificador" name="calcularDigitoVerificador">
+    </wsdl:input>
+      <wsdl:output message="tns:calcularDigitoVerificadorResponse" name="calcularDigitoVerificadorResponse">
+    </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="solicitarPostagemReversa">
+      <wsdl:input message="tns:solicitarPostagemReversa" name="solicitarPostagemReversa">
+    </wsdl:input>
+      <wsdl:output message="tns:solicitarPostagemReversaResponse" name="solicitarPostagemReversaResponse">
+    </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="solicitarRange">
+      <wsdl:input message="tns:solicitarRange" name="solicitarRange">
+    </wsdl:input>
+      <wsdl:output message="tns:solicitarRangeResponse" name="solicitarRangeResponse">
+    </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="solicitarPostagemSimultanea">
+      <wsdl:input message="tns:solicitarPostagemSimultanea" name="solicitarPostagemSimultanea">
+    </wsdl:input>
+      <wsdl:output message="tns:solicitarPostagemSimultaneaResponse" name="solicitarPostagemSimultaneaResponse">
+    </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="acompanharPedido">
+      <wsdl:input message="tns:acompanharPedido" name="acompanharPedido">
+    </wsdl:input>
+      <wsdl:output message="tns:acompanharPedidoResponse" name="acompanharPedidoResponse">
+    </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="validarPostagemReversa">
+      <wsdl:input message="tns:validarPostagemReversa" name="validarPostagemReversa">
+    </wsdl:input>
+      <wsdl:output message="tns:validarPostagemReversaResponse" name="validarPostagemReversaResponse">
+    </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="cancelarPedido">
+      <wsdl:input message="tns:cancelarPedido" name="cancelarPedido">
+    </wsdl:input>
+      <wsdl:output message="tns:cancelarPedidoResponse" name="cancelarPedidoResponse">
+    </wsdl:output>
+    </wsdl:operation>
+  </wsdl:portType>
+  <wsdl:binding name="WebServiceScolSoapBinding" type="tns:WebServiceScol">
+    <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+    <wsdl:operation name="calcularDigitoVerificador">
+      <soap:operation soapAction="" style="document"/>
+      <wsdl:input name="calcularDigitoVerificador">
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output name="calcularDigitoVerificadorResponse">
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="solicitarPostagem">
+      <soap:operation soapAction="" style="document"/>
+      <wsdl:input name="solicitarPostagem">
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output name="solicitarPostagemResponse">
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="validarPostagemSimultanea">
+      <soap:operation soapAction="" style="document"/>
+      <wsdl:input name="validarPostagemSimultanea">
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output name="validarPostagemSimultaneaResponse">
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="solicitarPostagemReversa">
+      <soap:operation soapAction="" style="document"/>
+      <wsdl:input name="solicitarPostagemReversa">
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output name="solicitarPostagemReversaResponse">
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="solicitarRange">
+      <soap:operation soapAction="" style="document"/>
+      <wsdl:input name="solicitarRange">
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output name="solicitarRangeResponse">
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="solicitarPostagemSimultanea">
+      <soap:operation soapAction="" style="document"/>
+      <wsdl:input name="solicitarPostagemSimultanea">
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output name="solicitarPostagemSimultaneaResponse">
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="acompanharPedido">
+      <soap:operation soapAction="" style="document"/>
+      <wsdl:input name="acompanharPedido">
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output name="acompanharPedidoResponse">
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="validarPostagemReversa">
+      <soap:operation soapAction="" style="document"/>
+      <wsdl:input name="validarPostagemReversa">
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output name="validarPostagemReversaResponse">
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="cancelarPedido">
+      <soap:operation soapAction="" style="document"/>
+      <wsdl:input name="cancelarPedido">
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output name="cancelarPedidoResponse">
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+  </wsdl:binding>
+  <wsdl:service name="WebServiceScol">
+    <wsdl:port binding="tns:WebServiceScolSoapBinding" name="WebServiceScolPort">
+      <soap:address location="http://webservicescolhomologacao.correios.com.br/ScolWeb/WebServiceScol"/>
+    </wsdl:port>
+  </wsdl:service>
+</wsdl:definitions>

--- a/spec/fixtures/requests/collect_number_request.xml
+++ b/spec/fixtures/requests/collect_number_request.xml
@@ -51,14 +51,14 @@
       <item>127078</item>
       <id>1405670</id>
       <desc>Pen Drive SAndisk 16GB SDCZ50-016G-A95</desc>
-      <ship>ship</ship>
+      <entrega>ship</entrega>
       <num>1</num>
     </obj_col>
     <obj_col>
       <item>277574</item>
       <id>1405670</id>
       <desc>Chip unico claro Pre pago</desc>
-      <ship>ship</ship>
+      <entrega>ship</entrega>
       <num>2</num>
     </obj_col>
   </coletas_solicitadas>


### PR DESCRIPTION
# Main changes

##  Add right sandbox WSDL

The WSDL used in tests uses the production WSDL of Correios and this commit creates the sandbox one that is available at: http://webservicescolhomologacao.correios.com.br/ScolWeb/WebServiceScol?wsdl

## Adds new option to Savon client for test environments

Savon client gets lost because of the way the sandbox WSDL is built. This commit do a fix in it (see
savonrb/savon#537 for more info) by doing this you is possible to use the gem in test environments.

##  	Change object's property "ship" to "entrega"

The property ```ship``` of ```Object``` should be ```entrega``` in order to work in the sandbox environment the same should apply to production.