### PR TITLE
Add a configuration to set the development WSDL endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ CorreiosSigep.configure do |config|
 end
 ```
 
+Para utilizar o ambiente de homologação dos correios, adicione essa configuração:
+
+```ruby
+  config.development = true
+```
+
 Se for necessário, é possível adicionar também um proxy.
 
 ```ruby

--- a/bin/console
+++ b/bin/console
@@ -1,0 +1,14 @@
+#!/usr/bin/env ruby
+
+require 'bundler/setup'
+require 'correios_sigep'
+
+# You can add fixtures and/or initialization code here to make experimenting
+# with your gem easier. You can also use a different console, if you like.
+
+# (If you use this, don't forget to add pry to your Gemfile!)
+# require "pry"
+# Pry.start
+
+require 'irb'
+IRB.start

--- a/lib/correios_sigep/configuration.rb
+++ b/lib/correios_sigep/configuration.rb
@@ -1,6 +1,6 @@
 module CorreiosSigep
   class Configuration
-    attr_accessor :administrative_code, :card, :service_code, :wsdl_base_url,
+    attr_accessor :administrative_code, :card, :development, :service_code, :wsdl_base_url,
                   :proxy, :timeout, :user, :password
 
     def administrative_fields
@@ -9,6 +9,10 @@ module CorreiosSigep
                                          card: card,
                                          service_code: service_code)
 
+    end
+
+    def development?
+      @development
     end
   end
 end

--- a/lib/correios_sigep/logistic_reverse/base_client.rb
+++ b/lib/correios_sigep/logistic_reverse/base_client.rb
@@ -23,7 +23,7 @@ module CorreiosSigep
       end
 
       def wsdl
-        @wsdl ||= if ENV['GEM_ENV'] == 'test'
+        @wsdl ||= if ENV['GEM_ENV'] == 'test' || CorreiosSigep.configuration.development?
                     'https://apphom.correios.com.br/logisticaReversaWS/logisticaReversaService/logisticaReversaWS?wsdl'
                   else
                     'https://cws.correios.com.br/logisticaReversaWS/logisticaReversaService/logisticaReversaWS?wsdl'

--- a/lib/correios_sigep/version.rb
+++ b/lib/correios_sigep/version.rb
@@ -1,3 +1,3 @@
 module CorreiosSigep
-  VERSION = '2.1.1'.freeze
+  VERSION = '2.2.0'.freeze
 end

--- a/spec/correios_sigep/configuration_spec.rb
+++ b/spec/correios_sigep/configuration_spec.rb
@@ -28,6 +28,24 @@ module CorreiosSigep
       end
     end
 
+    describe '#development=' do
+      it 'sets if it is the development environment' do
+        subject.development = true
+        expect(subject.development).to be_truthy
+      end
+    end
+
+    describe '#development?' do
+      it 'returns falsey if not set' do
+        expect(subject.development?).to be_falsey
+      end
+
+      it 'returns the configuration value' do
+        subject.development = true
+        expect(subject.development?).to be_truthy
+      end
+    end
+
     describe '#service_code' do
       it 'returns nil when unset' do
         expect(subject.service_code).to be_nil

--- a/spec/correios_sigep/logistic_reverse/base_client_spec.rb
+++ b/spec/correios_sigep/logistic_reverse/base_client_spec.rb
@@ -5,6 +5,29 @@ module CorreiosSigep
     describe BaseClient do
       let(:user) { CorreiosSigep.configuration.user }
       let(:pass) { CorreiosSigep.configuration.password }
+      let(:default_params) do
+        {
+          adapter: :net_http_persistent,
+          open_timeout: CorreiosSigep::LogisticReverse::BaseClient::DEFAULT_TIMEOUT,
+          read_timeout: CorreiosSigep::LogisticReverse::BaseClient::DEFAULT_TIMEOUT,
+          basic_auth: [user, pass],
+          headers: { 'SOAPAction' => '' }
+        }
+      end
+
+      context 'using the development configuration' do
+        subject { described_class.new }
+
+        before { CorreiosSigep.configuration.development = true }
+        let(:params) do
+          default_params.merge({wsdl: 'https://apphom.correios.com.br/logisticaReversaWS/logisticaReversaService/logisticaReversaWS?wsdl' })
+        end
+
+        it 'initializes @client with test WSDL' do
+          expect(Savon).to receive(:client).with(params) { true }
+          subject
+        end
+      end
 
       context 'setting up a proxy' do
         subject { described_class.new }


### PR DESCRIPTION
We don't have a way to use the develpment WSDL on the gem. This commit
adds a new configuration:
 - development: If it is set to true, will use the development WSDL from
 Correios