### PR TITLE
Remove Bundler version restriction on Gemspec

### DIFF
--- a/correios_sigep.gemspec
+++ b/correios_sigep.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'net-http-persistent', '~> 2.9.4'
   spec.add_dependency 'savon', '~> 2.11'
 
-  spec.add_development_dependency 'bundler', '~> 1.7'
+  spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'pry', '~> 0.10'
   spec.add_development_dependency 'coveralls'
   spec.add_development_dependency 'rake', '~> 10.0'


### PR DESCRIPTION
This commit will remove the bundler ~> 1.7 version restriction on the
gemspec. This is avoiding us to use Bundler 2 to install dependencies.