### PR TITLE
Upgrade Rake dependency to >= 12.3.3

### DIFF
--- a/correios_sigep.gemspec
+++ b/correios_sigep.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'pry', '~> 0.10'
   spec.add_development_dependency 'coveralls'
-  spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency 'rake', '>= 12.3.3'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'simplecov', '~> 0.9'
   spec.add_development_dependency 'webmock', '~> 2.3'

--- a/correios_sigep.gemspec
+++ b/correios_sigep.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'net-http-persistent', '~> 2.9.4'
   spec.add_dependency 'savon', '~> 2.11'
 
-  spec.add_development_dependency 'bundler', '~> 1.7'
+  spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'pry', '~> 0.10'
   spec.add_development_dependency 'coveralls'
   spec.add_development_dependency 'rake', '~> 10.0'


### PR DESCRIPTION
Rake <= 12.3 is affected by CVE-2020-8130. This commit upgrades our
version on Gemspec.